### PR TITLE
Bundle fabric-networking-api and bump to 1.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,9 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	// Fabric API. This is technically optional, but you probably want it anyway.
-	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
+	// Bundle necessary Fabric API module
+	modImplementation fabricApi.module("fabric-networking-api-v1", project.fabric_version)
+	include fabricApi.module("fabric-networking-api-v1", project.fabric_version)
 
 	modImplementation "me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}"
 	include "me.sargunvohra.mcmods:autoconfig1u:${project.auto_config_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,10 +6,10 @@ minecraft_version=1.16.5
 yarn_mappings=1.16.5+build.4
 loader_version=0.11.1
 # Mod Properties
-mod_version=1.1.0
+mod_version=1.1.1
 maven_group=one.oktw
 archives_base_name=FabricProxy-Lite
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_version=0.30.0+1.16
+fabric_version=0.30.3+1.16
 auto_config_version=3.3.1

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,6 +28,6 @@
 
   "depends": {
     "fabricloader": ">=0.7.4",
-    "fabric": ">=0.28"
+    "fabric-networking-api-v1": "*"
   }
 }


### PR DESCRIPTION
Allows the mod to be used without the full fabric API jar. By extension this enables use on 1.16 and 1.16.1 since fabric-networking-api-v1 was never officially released for them. Runs fine and I didn't find any relevant differences between 1.16 and 1.16.5 for either the networking api or fabric proxy in the game code.