### PR TITLE
Support modifying the disconnection message

### DIFF
--- a/src/main/java/one/oktw/ModConfig.java
+++ b/src/main/java/one/oktw/ModConfig.java
@@ -13,10 +13,10 @@ public class ModConfig {
         if (env == null) {
             return disconnectMessage;
         } else {
-            return (env);
+            return env;
         }
     }
-    
+
     public boolean getHackOnlineMode() {
         String env = System.getenv("FABRIC_PROXY_HACK_ONLINE_MODE");
         if (env == null) {

--- a/src/main/java/one/oktw/ModConfig.java
+++ b/src/main/java/one/oktw/ModConfig.java
@@ -5,8 +5,18 @@ public class ModConfig {
     private boolean hackOnlineMode = true;
     private boolean hackEarlySend = false;
     private boolean hackMessageChain = true;
+    private String disconnectMessage = "This server requires you to connect with Velocity.";
     private String secret = "";
 
+    public String getAbortedMessage() {
+        String env = System.getenv("FABRIC_PROXY_MESSAGE");
+        if (env == null) {
+            return disconnectMessage;
+        } else {
+            return (env);
+        }
+    }
+    
     public boolean getHackOnlineMode() {
         String env = System.getenv("FABRIC_PROXY_HACK_ONLINE_MODE");
         if (env == null) {

--- a/src/main/java/one/oktw/PacketHandler.java
+++ b/src/main/java/one/oktw/PacketHandler.java
@@ -25,7 +25,7 @@ class PacketHandler {
 
     void handleVelocityPacket(MinecraftServer server, ServerLoginNetworkHandler handler, boolean understood, PacketByteBuf buf, ServerLoginNetworking.LoginSynchronizer synchronizer, PacketSender ignored) {
         if (!understood) {
-            handler.disconnect(Text.of("This server requires you to connect with Velocity."));
+            handler.disconnect(Text.of(config.getAbortedMessage()));
             return;
         }
 


### PR DESCRIPTION
Support modifying the disconnection message when trying to connect directly to the server

You can change the message `This server requires you to connect with Velocity.` to your own's.

This can be edited in config files.