### PR TITLE
Add option to 'allowProxyBypass', 'allowLocalOffline' and 'localIp' to support #45

### DIFF
--- a/src/main/java/one/oktw/ModConfig.java
+++ b/src/main/java/one/oktw/ModConfig.java
@@ -1,11 +1,15 @@
 package one.oktw;
 
-@SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal"})
+@SuppressWarnings({ "FieldCanBeLocal", "FieldMayBeFinal" })
 public class ModConfig {
     private boolean hackOnlineMode = true;
     private boolean hackEarlySend = false;
     private boolean hackMessageChain = true;
     private String disconnectMessage = "This server requires you to connect with Velocity.";
+    private boolean allowBypassProxy = false;
+    private boolean allowLocalOffline = false;
+    private String localIp = "/127.0.0.1";
+
     private String secret = "";
 
     public String getAbortedMessage() {
@@ -21,6 +25,23 @@ public class ModConfig {
         String env = System.getenv("FABRIC_PROXY_HACK_ONLINE_MODE");
         if (env == null) {
             return hackOnlineMode;
+        } else {
+            return Boolean.parseBoolean(env);
+        }
+    }
+    public String getLocalIp() {
+        String env = System.getenv("FABRIC_PROXY_LOCAL_IP");
+        if (env == null) {
+            return localIp;
+        } else {
+            return env;
+        }
+    }
+
+    public boolean getAllowLocalOffline() {
+        String env = System.getenv("FABRIC_PROXY_ALLOW_LOCAL_OFFLINE");
+        if (env == null) {
+            return allowLocalOffline;
         } else {
             return Boolean.parseBoolean(env);
         }
@@ -52,4 +73,14 @@ public class ModConfig {
             return env;
         }
     }
+
+    public boolean getallowBypassProxy() {
+        String env = System.getenv("ALLOW_BYPASS_PROXY");
+        if (env == null) {
+            return allowBypassProxy;
+        } else {
+            return Boolean.parseBoolean(env);
+        }
+    }
+
 }

--- a/src/main/java/one/oktw/mixin/hack/ServerLoginNetworkHandler_SkipKeyPacket.java
+++ b/src/main/java/one/oktw/mixin/hack/ServerLoginNetworkHandler_SkipKeyPacket.java
@@ -1,15 +1,33 @@
 package one.oktw.mixin.hack;
 
+import net.minecraft.network.ClientConnection;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerLoginNetworkHandler;
+import one.oktw.FabricProxyLite;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(ServerLoginNetworkHandler.class)
 public class ServerLoginNetworkHandler_SkipKeyPacket {
+    @Redirect(method = "onHello", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/ClientConnection;isLocal()Z"))
+    private boolean checkIsLocal(ClientConnection connection) {
+        // To make local address (Velocity) be able to connect the server. 
+        // WARN: This also allows local players to join the server without login.
+        if (FabricProxyLite.config.getAllowLocalOffline()) {
+            String ip = connection.getAddressAsString(true);
+            if (ip.startsWith(FabricProxyLite.config.getLocalIp())){
+                return true;
+            }
+            return false;
+        }
+        return connection.isLocal();
+    }
+
     @Redirect(method = "onHello", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;isOnlineMode()Z"))
     private boolean skipKeyPacket(MinecraftServer minecraftServer) {
-        return false;
+        if (!FabricProxyLite.config.getallowBypassProxy())
+            return false;
+        return minecraftServer.isOnlineMode();
     }
 }


### PR DESCRIPTION
If you wish to join not trough the proxy, enable `allowBypassProxy`, `allowLocalOffline` and set `localIp` to your proxy address (For exaple: `/127.0.0.1`).

**This feature conflicts with `hackEarlySend`**

This will allow the local players (Or the address you set) to join without logging in (Offline mode).

It works fine on my server