### PR TITLE
Config Refactor, support secret file and read-only config

### DIFF
--- a/src/main/java/one/oktw/FabricProxyLite.java
+++ b/src/main/java/one/oktw/FabricProxyLite.java
@@ -1,18 +1,13 @@
 package one.oktw;
 
-import com.moandjiezana.toml.Toml;
-import com.moandjiezana.toml.TomlWriter;
 import net.fabricmc.api.DedicatedServerModInitializer;
 import net.fabricmc.fabric.api.networking.v1.ServerLoginConnectionEvents;
 import net.fabricmc.fabric.api.networking.v1.ServerLoginNetworking;
 import net.fabricmc.loader.api.FabricLoader;
-import org.apache.logging.log4j.LogManager;
 import org.objectweb.asm.tree.ClassNode;
 import org.spongepowered.asm.mixin.extensibility.IMixinConfigPlugin;
 import org.spongepowered.asm.mixin.extensibility.IMixinInfo;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
 
@@ -37,18 +32,7 @@ public class FabricProxyLite implements DedicatedServerModInitializer, IMixinCon
         if (config != null) return;
 
         var configFile = FabricLoader.getInstance().getConfigDir().resolve("FabricProxy-Lite.toml");
-        if (!Files.exists(configFile)) {
-            config = new ModConfig();
-        } else {
-            config = new Toml().read(configFile.toFile()).to(ModConfig.class);
-        }
-
-        // Update config
-        try {
-            new TomlWriter().write(config, configFile.toFile());
-        } catch (IOException e) {
-            LogManager.getLogger().error("Init config failed.", e);
-        }
+        config = ModConfig.load(configFile);
     }
 
     @Override

--- a/src/main/java/one/oktw/ModConfig.java
+++ b/src/main/java/one/oktw/ModConfig.java
@@ -4,6 +4,7 @@ import com.moandjiezana.toml.Toml;
 import com.moandjiezana.toml.TomlWriter;
 import org.apache.logging.log4j.LogManager;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,10 +24,15 @@ public class ModConfig {
             config = new ModConfig();
         }
 
-        try {
-            new TomlWriter().write(config, configPath.toFile());
-        } catch (IOException e) {
-            LogManager.getLogger().error("Init config failed.", e);
+        File configFile = configPath.toFile();
+        if(configFile.canWrite()) {
+            try {
+                new TomlWriter().write(config, configFile);
+            } catch (IOException e) {
+                LogManager.getLogger().error("Init config failed.", e);
+            }
+        } else {
+            LogManager.getLogger().info("FabricProxy-Lite Config file is not writable");
         }
 
         String envHackOnlineMode = System.getenv("FABRIC_PROXY_HACK_ONLINE_MODE");

--- a/src/main/java/one/oktw/ModConfig.java
+++ b/src/main/java/one/oktw/ModConfig.java
@@ -1,6 +1,13 @@
 package one.oktw;
 
-@SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal"})
+import com.moandjiezana.toml.Toml;
+import com.moandjiezana.toml.TomlWriter;
+import org.apache.logging.log4j.LogManager;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 public class ModConfig {
     private boolean hackOnlineMode = true;
     private boolean hackEarlySend = false;
@@ -8,48 +15,65 @@ public class ModConfig {
     private String disconnectMessage = "This server requires you to connect with Velocity.";
     private String secret = "";
 
-    public String getAbortedMessage() {
-        String env = System.getenv("FABRIC_PROXY_MESSAGE");
-        if (env == null) {
-            return disconnectMessage;
+    public static ModConfig load(Path configPath) {
+        ModConfig config;
+        if(Files.exists(configPath)) {
+            config = new Toml().read(configPath.toFile()).to(ModConfig.class);
         } else {
-            return env;
+            config = new ModConfig();
         }
+
+        try {
+            new TomlWriter().write(config, configPath.toFile());
+        } catch (IOException e) {
+            LogManager.getLogger().error("Init config failed.", e);
+        }
+
+        String envHackOnlineMode = System.getenv("FABRIC_PROXY_HACK_ONLINE_MODE");
+        if(envHackOnlineMode != null) {
+            config.hackOnlineMode = Boolean.parseBoolean(envHackOnlineMode);
+        }
+
+        String envHackSendEarly = System.getenv("FABRIC_PROXY_HACK_FABRIC_API");
+        if(envHackSendEarly != null) {
+            config.hackEarlySend = Boolean.parseBoolean(envHackSendEarly);
+        }
+
+        String envHackMessageChain = System.getenv("FABRIC_PROXY_HACK_MESSAGE_CHAIN");
+        if(envHackMessageChain != null) {
+            config.hackMessageChain = Boolean.parseBoolean(envHackMessageChain);
+        }
+
+        String envDisconnectMessage = System.getenv("FABRIC_PROXY_MESSAGE");
+        if(envDisconnectMessage != null) {
+            config.disconnectMessage = envDisconnectMessage;
+        }
+
+        String envSecret = System.getenv("FABRIC_PROXY_SECRET");
+        if(envSecret != null) {
+            config.secret = envSecret;
+        }
+
+        return config;
+    }
+
+    public String getAbortedMessage() {
+        return disconnectMessage;
     }
 
     public boolean getHackOnlineMode() {
-        String env = System.getenv("FABRIC_PROXY_HACK_ONLINE_MODE");
-        if (env == null) {
-            return hackOnlineMode;
-        } else {
-            return Boolean.parseBoolean(env);
-        }
+        return hackOnlineMode;
     }
 
     public boolean getHackEarlySend() {
-        String env = System.getenv("FABRIC_PROXY_HACK_FABRIC_API");
-        if (env == null) {
-            return hackEarlySend;
-        } else {
-            return Boolean.parseBoolean(env);
-        }
+        return hackEarlySend;
     }
 
     public boolean getHackMessageChain() {
-        String env = System.getenv("FABRIC_PROXY_HACK_MESSAGE_CHAIN");
-        if (env == null) {
-            return hackMessageChain;
-        } else {
-            return Boolean.parseBoolean(env);
-        }
+        return hackMessageChain;
     }
 
     public String getSecret() {
-        String env = System.getenv("FABRIC_PROXY_SECRET");
-        if (env == null) {
-            return secret;
-        } else {
-            return env;
-        }
+        return secret;
     }
 }

--- a/src/main/java/one/oktw/ModConfig.java
+++ b/src/main/java/one/oktw/ModConfig.java
@@ -52,6 +52,15 @@ public class ModConfig {
         String envSecret = System.getenv("FABRIC_PROXY_SECRET");
         if(envSecret != null) {
             config.secret = envSecret;
+        } else {
+            String envSecretFile = System.getenv("FABRIC_PROXY_SECRET_FILE");
+            if(envSecretFile != null) {
+                try {
+                    config.secret = Files.readString(Path.of(envSecretFile));
+                } catch (IOException e) {
+                    LogManager.getLogger().error("Unable to read secret file {}: {}", envSecretFile, e);
+                }
+            }
         }
 
         return config;


### PR DESCRIPTION
This pull request refactors the config loading into `ModConfig` and moves the environment var loading from the getters into the initial config loading.

This also adds a new `FABRIC_PROXY_SECRET_FILE` environment variable that can be used to load the secret from a file (e.g. `/var/lib/velocity/forwarding.secret`).

I also implemented that read-only config files no longer result in an error and it'll just inform the user that it is read-only.