### PR TITLE
Update to Minecraft 1.21.8 and Java 21 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '1.6-SNAPSHOT'
+	id 'fabric-loom' version '1.11-SNAPSHOT'
 	id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://fabricmc.net/develop/
-minecraft_version=1.21
-yarn_mappings=1.21+build.1
-loader_version=0.15.11
+minecraft_version=1.21.8
+yarn_mappings=1.21.8+build.1
+loader_version=0.16.14
 # Mod Properties
 mod_version=2.9.0
 maven_group=one.oktw
 archives_base_name=FabricProxy-Lite
 # Dependencies
 # currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-fabric_version=0.100.1+1.21
+fabric_version=0.130.0+1.21.8

--- a/src/main/resources/core.mixins.json
+++ b/src/main/resources/core.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "one.oktw.mixin.core",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "ClientConnection_AddressAccessor",
     "ServerLoginNetworkHandlerAccessor"

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -23,9 +23,9 @@
     "hack.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15.11",
+    "fabricloader": ">=0.16.14",
     "fabric-networking-api-v1": "*",
-    "minecraft": ">=1.21",
+    "minecraft": ">=1.21.8",
     "java": ">=21"
   }
 }

--- a/src/main/resources/hack.mixins.json
+++ b/src/main/resources/hack.mixins.json
@@ -3,7 +3,7 @@
   "minVersion": "0.8",
   "package": "one.oktw.mixin.hack",
   "plugin": "one.oktw.FabricProxyLite",
-  "compatibilityLevel": "JAVA_17",
+  "compatibilityLevel": "JAVA_21",
   "mixins": [
     "ServerLoginNetworkHandler_EarlySendPacket",
     "ServerLoginNetworkHandler_SkipKeyPacket",


### PR DESCRIPTION
Bump Minecraft version to 1.21.8, update Fabric loader and API dependencies, and set compatibility level to JAVA_21 in mixin configs. This ensures the project is compatible with the latest Minecraft and Java versions.