### PR TITLE
Prepare for version v2.12.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,19 @@ jobs:
           cache-disabled: true
       - name: Build
         run: ./gradlew build
+      - name: SHA256 Checksum
+        if: ${{ runner.os == 'Linux' && matrix.java == '25' }} # Only upload artifacts built from LTS java on one OS
+        run: sha256sum build/libs/* >> sha256.txt
+      - name: Publish Checksum Output to Summary
+        if: ${{ runner.os == 'Linux' && matrix.java == '25' }} # Only upload artifacts built from LTS java on one OS
+        run: |
+          {
+            echo "### Artifact SHA256"
+            echo '```terraform'
+            cat sha256.txt
+            echo '```'
+            echo "### Gradle Summary"
+          } >> $GITHUB_STEP_SUMMARY
       - name: Capture build artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '25' }} # Only upload artifacts built from LTS java on one OS
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,21 +20,21 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Validate gradle wrapper
-        uses: gradle/actions/wrapper-validation@v4
+        uses: gradle/actions/wrapper-validation@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
       - name: Setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
       - name: Build
         run: ./gradlew build
       - name: Capture build artifacts
         if: ${{ runner.os == 'Linux' && matrix.java == '25' }} # Only upload artifacts built from LTS java on one OS
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: Artifacts
           path: build/libs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,8 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@39e147cb9de83bb9910b8ef8bd7fff0ee20fcd6f # v6.0.1
+        with:
+          cache-disabled: true
       - name: Build
         run: ./gradlew build
       - name: Capture build artifacts

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-project = "2.11.1"
+project = "2.12.0"
 java = "25"
 minecraft = "26.1"
 


### PR DESCRIPTION
- [CI] Update actions and pin version
- [CI] Disable gradle actions cache
- [CI] Calculate artifact sha256
- Bump minecraft version 26.1 #146 
- Bump version to 2.12.0
- Closes #145 